### PR TITLE
Darwin Build

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Toxic is a [Tox](https://tox.im)-based instant messenging client which formerly 
   * `DISABLE_SOUND_NOTIFY=1` → build toxic without sound notifications support
   * `DISABLE_DESKTOP_NOTIFY=1` → build toxic without desktop notifications support
 
+### OS X Compile
+Using [Homebrew](http://brew.sh): `brew install openal-soft freealut libconfig && brew install https://raw.githubusercontent.com/Tox/homebrew-tox/master/Formula/libtoxcore.rb && brew install https://raw.githubusercontent.com/Homebrew/homebrew-x11/master/libnotify.rb`.
+
+You can omit `libnotify` if you intend to build without desktop notifications enabled. 
+
 ### Packaging
 * For packaging purpose, you can use `DESTDIR=""` to specify a directory where to store installed files
 * `DESTDIR=""` can be used in addition to `PREFIX=""`:

--- a/cfg/systems/Darwin.mk
+++ b/cfg/systems/Darwin.mk
@@ -1,0 +1,10 @@
+# Special options for OS X
+# This assumes the use of Homebrew. Change the paths if using MacPorts or Fink.
+
+PKG_CONFIG_PATH = $(shell export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/local/opt/libconfig/lib/pkgconfig:/usr/local/lib/pkgconfig:/opt/X11/lib/pkgconfig)
+
+LIBS := $(filter-out ncursesw, $(LIBS))
+
+# OS X ships a usable, recent version of ncurses, but calls it ncurses not ncursesw.
+LDFLAGS += -lncurses -lalut -ltoxav -ltoxcore -ltoxdns -lresolv -lconfig -ltoxencryptsave -g
+CFLAGS += -I/usr/local/opt/freealut/include/AL -I/usr/local/opt/glib/include/glib-2.0 -g


### PR DESCRIPTION
Explains/Better Enables building on the OS X Platform. I’ve written a
Darwin.mk file for the purpose, given one is referenced in the Makefile
but doesn’t actually exist yet. I presume this is due to Toxic’s recent
move away from configure scripts?

Anyhow. It’s not perfect, and it could be prettier, but it should fix