### PR TITLE
Add support for custom timestamps in chat and logs.

### DIFF
--- a/doc/toxic.conf.5
+++ b/doc/toxic.conf.5
@@ -2,12 +2,12 @@
 .\"     Title: toxic.conf
 .\"    Author: [see the "AUTHORS" section]
 .\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 2015-02-08
+.\"      Date: 2015-02-19
 .\"    Manual: Toxic Manual
 .\"    Source: toxic __VERSION__
 .\"  Language: English
 .\"
-.TH "TOXIC\&.CONF" "5" "2015\-02\-08" "toxic __VERSION__" "Toxic Manual"
+.TH "TOXIC\&.CONF" "5" "2015\-02\-19" "toxic __VERSION__" "Toxic Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -66,6 +66,23 @@ Configuration related to interface elements\&.
 Enable or disable timestamps\&. true or false
 .RE
 .PP
+\fBtime_format\fR
+.RS 4
+Select between 24 and 12 hour time\&. Specify 24 or 12\&. Setting timestamp_format and log_timestamp_format will override this setting\&.
+.RE
+.PP
+\fBtimestamp_format\fR
+.RS 4
+Time format string for the interface enclosed by double quotes\&. See
+\fBdate\fR(1)
+.RE
+.PP
+\fBlog_timestamp_format\fR
+.RS 4
+Time format string for logging enclosed by double quotes\&. See
+\fBdate\fR(1)
+.RE
+.PP
 \fBalerts\fR
 .RS 4
 Enable or disable terminal alerts on events\&. true or false
@@ -79,11 +96,6 @@ Select between native terminal colors and toxic color theme\&. true or false
 \fBautolog\fR
 .RS 4
 Enable or disable autologging\&. true or false
-.RE
-.PP
-\fBtime_format\fR
-.RS 4
-Select between 24 and 12 hour time\&. Specify 24 or 12
 .RE
 .PP
 \fBshow_typing_other\fR

--- a/doc/toxic.conf.5.asc
+++ b/doc/toxic.conf.5.asc
@@ -42,6 +42,18 @@ OPTIONS
     *timestamps*;;
         Enable or disable timestamps. true or false
 
+    *time_format*;;
+	Select between 24 and 12 hour time. Specify 24 or 12. Setting
+        timestamp_format and log_timestamp_format will override this setting.
+
+    *timestamp_format*;;
+        Time format string for the interface enclosed by double quotes.
+        See *date*(1)
+
+    *log_timestamp_format*;;
+        Time format string for logging enclosed by double quotes.
+        See *date*(1)
+
     *alerts*;;
         Enable or disable terminal alerts on events. true or false
 
@@ -50,9 +62,6 @@ OPTIONS
 
     *autolog*;;
         Enable or disable autologging. true or false
-
-    *time_format*;;
-        Select between 24 and 12 hour time. Specify 24 or 12
 
     *show_typing_other*;;
         Show when others are typing in a 1-on-1 chat. true or false

--- a/misc/toxic.conf.example
+++ b/misc/toxic.conf.example
@@ -17,6 +17,9 @@ ui = {
   // 24 or 12 hour time
   time_format=24;
 
+  // timestamp format string according to date/strftime format. Overrides time_format setting
+  timestamp_format="%H:%M:%S";
+
   // true to show you when others are typing a message in 1-on-1 chats
   show_typing_other=true;
 

--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -299,7 +299,7 @@ static void update_friend_last_online(int32_t num, uint64_t timestamp)
     Friends.list[num].last_online.tm = *localtime((const time_t*)&timestamp);
 
     /* if the format changes make sure TIME_STR_SIZE is the correct size */
-    const char *t = user_settings->time == TIME_12 ? "%I:%M %p" : "%H:%M";
+    const char *t = user_settings->timestamp_format;
     strftime(Friends.list[num].last_online.hour_min_str, TIME_STR_SIZE, t,
              &Friends.list[num].last_online.tm);
 }

--- a/src/line_info.c
+++ b/src/line_info.c
@@ -202,7 +202,7 @@ void line_info_add(ToxWindow *self, const char *timestr, const char *name1, cons
 
     if (timestr) {
         snprintf(new_line->timestr, sizeof(new_line->timestr), "%s", timestr);
-        len += strlen(new_line->timestr);
+        len += strlen(new_line->timestr) + 1;
     }
 
     if (name1) {
@@ -302,7 +302,7 @@ void line_info_print(ToxWindow *self)
             case OUT_MSG_READ:
             case IN_MSG:
                 wattron(win, COLOR_PAIR(BLUE));
-                wprintw(win, "%s", line->timestr);
+                wprintw(win, "%s ", line->timestr);
                 wattroff(win, COLOR_PAIR(BLUE));
 
                 int nameclr = GREEN;
@@ -342,7 +342,7 @@ void line_info_print(ToxWindow *self)
             case OUT_ACTION:
             case IN_ACTION:
                 wattron(win, COLOR_PAIR(BLUE));
-                wprintw(win, "%s", line->timestr);
+                wprintw(win, "%s ", line->timestr);
                 wattroff(win, COLOR_PAIR(BLUE));
 
                 wattron(win, COLOR_PAIR(YELLOW));
@@ -366,7 +366,7 @@ void line_info_print(ToxWindow *self)
             case SYS_MSG:
                 if (line->timestr[0]) {
                     wattron(win, COLOR_PAIR(BLUE));
-                    wprintw(win, "%s", line->timestr);
+                    wprintw(win, "%s ", line->timestr);
                     wattroff(win, COLOR_PAIR(BLUE));
                 }
 
@@ -399,7 +399,7 @@ void line_info_print(ToxWindow *self)
 
             case CONNECTION:
                 wattron(win, COLOR_PAIR(BLUE));
-                wprintw(win, "%s", line->timestr);
+                wprintw(win, "%s ", line->timestr);
                 wattroff(win, COLOR_PAIR(BLUE));
 
                 wattron(win, COLOR_PAIR(line->colour));
@@ -416,7 +416,7 @@ void line_info_print(ToxWindow *self)
 
             case DISCONNECTION:
                 wattron(win, COLOR_PAIR(BLUE));
-                wprintw(win, "%s", line->timestr);
+                wprintw(win, "%s ", line->timestr);
                 wattroff(win, COLOR_PAIR(BLUE));
 
                 wattron(win, COLOR_PAIR(line->colour));
@@ -433,7 +433,7 @@ void line_info_print(ToxWindow *self)
 
             case NAME_CHANGE:
                 wattron(win, COLOR_PAIR(BLUE));
-                wprintw(win, "%s", line->timestr);
+                wprintw(win, "%s ", line->timestr);
                 wattroff(win, COLOR_PAIR(BLUE));
 
                 wattron(win, COLOR_PAIR(MAGENTA));

--- a/src/log.c
+++ b/src/log.c
@@ -134,7 +134,7 @@ void write_to_log(const char *msg, const char *name, struct chatlog *log, bool e
     else
         snprintf(name_frmt, sizeof(name_frmt), "%s:", name);
 
-    const char *t = user_settings->time == TIME_12 ? "%Y/%m/%d [%I:%M:%S %p]" : "%Y/%m/%d [%H:%M:%S]";
+    const char *t = user_settings->log_timestamp_format;
     char s[MAX_STR_SIZE];
     strftime(s, MAX_STR_SIZE, t, get_time());
     fprintf(log->file, "%s %s %s\n", s, name_frmt, msg);

--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -87,7 +87,7 @@ void get_time_str(char *buf, int bufsize)
         return;
     }
 
-    const char *t = user_settings->time == TIME_12 ? "%I:%M:%S " : "%H:%M:%S ";
+    const char *t = user_settings->timestamp_format;
     strftime(buf, bufsize, t, get_time());
 }
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -32,8 +32,11 @@
 struct user_settings {
     int autolog;           /* boolean */
     int alerts;            /* boolean */
-    int time;              /* 12 or 24 */
+
     int timestamps;        /* boolean */
+    char timestamp_format[TIME_STR_SIZE];
+    char log_timestamp_format[TIME_STR_SIZE];
+
     int colour_theme;      /* boolean (0 for default toxic colours) */
     int history_size;      /* int between MIN_HISTORY and MAX_HISTORY */
     int show_typing_self;  /* boolean */
@@ -71,9 +74,6 @@ enum {
     AUTOLOG_OFF = 0,
     AUTOLOG_ON = 1,
 
-    TIME_24 = 24,
-    TIME_12 = 12,
-
     TIMESTAMPS_OFF = 0,
     TIMESTAMPS_ON = 1,
 
@@ -96,6 +96,8 @@ enum {
 #define LINE_QUIT    "<--"
 #define LINE_ALERT   "-!-"
 #define LINE_NORMAL  "---"
+#define TIMESTAMP_DEFAULT      "%H:%M:%S"
+#define LOG_TIMESTAMP_DEFAULT  "%Y/%m/%d [%H:%M:%S]"
 
 int settings_load(struct user_settings *s, const char *patharg);
 #endif /* #define SETTINGS_H */

--- a/src/toxic.h
+++ b/src/toxic.h
@@ -47,7 +47,7 @@
 #define MAX_CMDNAME_SIZE 64
 #define TOXIC_MAX_NAME_LENGTH 32   /* Must be <= TOX_MAX_NAME_LENGTH */
 #define KEY_IDENT_DIGITS 3    /* number of hex digits to display for the pub-key based identifier */
-#define TIME_STR_SIZE 16
+#define TIME_STR_SIZE 32
 
 /* ASCII key codes */
 #define T_KEY_ESC        0x1B     /* ESC key */


### PR DESCRIPTION
I increased the size of TIME_STR_SIZE to accomodate log timestamps.
Also have the old 24/12 format deprecated, but it might just make sense to have it removed altogether.