### PR TITLE
prevents cursor from blink

### DIFF
--- a/src/toxic.c
+++ b/src/toxic.c
@@ -175,7 +175,6 @@ static void init_term(void)
     cbreak();
     keypad(stdscr, 1);
     noecho();
-    timeout(100);
 
     if (has_colors()) {
         short bg_color = COLOR_BLACK;


### PR DESCRIPTION
This is a possible fix to: https://github.com/Tox/toxic/issues/194
I tested a bunch of the software and I didn't see any problem, this just solved the problem.
I don't know too much about ncurses stuffs, does this function have a function (in the software)?