### PR TITLE
Fixing couple leaking file descriptors

### DIFF
--- a/src/autocomplete.c
+++ b/src/autocomplete.c
@@ -284,6 +284,8 @@ int dir_match(ToxWindow *self, Tox *m, const wchar_t *line, const wchar_t *cmd)
         }
     }
 
+    closedir(dp);
+
     if (dircount == 0)
         return -1;
 

--- a/src/chat.c
+++ b/src/chat.c
@@ -325,6 +325,7 @@ static void chat_onFileSendRequest(ToxWindow *self, Tox *m, int32_t num, uint8_t
     int count = 1;
 
     while ((filecheck = fopen(filename, "r"))) {
+        fclose(filecheck);
         filename[len] = '\0';
         char d[9];
         sprintf(d, "(%d)", count++);


### PR DESCRIPTION
In `dir_match` and `chat_onFileSendRequest` functions, some temporary file descriptors were not closed after use. Now they are.