### PR TITLE
Makefile: allow overriding pkg-config

### DIFF
--- a/cfg/checks/av.mk
+++ b/cfg/checks/av.mk
@@ -8,13 +8,13 @@ else
 endif
 
 # Check if we can build audio support
-CHECK_AUDIO_LIBS = $(shell pkg-config --exists $(AUDIO_LIBS) || echo -n "error")
+CHECK_AUDIO_LIBS = $(shell $(PKG_CONFIG) --exists $(AUDIO_LIBS) || echo -n "error")
 ifneq ($(CHECK_AUDIO_LIBS), error)
     LIBS += $(AUDIO_LIBS)
     CFLAGS += $(AUDIO_CFLAGS)
     OBJ += $(AUDIO_OBJ)
 else ifneq ($(MAKECMDGOALS), clean)
-    MISSING_AUDIO_LIBS = $(shell for lib in $(AUDIO_LIBS) ; do if ! pkg-config --exists $$lib ; then echo $$lib ; fi ; done)
+    MISSING_AUDIO_LIBS = $(shell for lib in $(AUDIO_LIBS) ; do if ! $(PKG_CONFIG) --exists $$lib ; then echo $$lib ; fi ; done)
     $(warning WARNING -- Toxic will be compiled without audio support)
     $(warning WARNING -- You need these libraries for audio support)
     $(warning WARNING -- $(MISSING_AUDIO_LIBS))

--- a/cfg/checks/check_features.mk
+++ b/cfg/checks/check_features.mk
@@ -25,12 +25,12 @@ ifneq ($(DESK_NOTIFY), disabled)
 endif
 
 # Check if we can build Toxic
-CHECK_LIBS = $(shell pkg-config --exists $(LIBS) || echo -n "error")
+CHECK_LIBS = $(shell $(PKG_CONFIG) --exists $(LIBS) || echo -n "error")
 ifneq ($(CHECK_LIBS), error)
-    CFLAGS += $(shell pkg-config --cflags $(LIBS))
-    LDFLAGS += $(shell pkg-config --libs $(LIBS))
+    CFLAGS += $(shell $(PKG_CONFIG) --cflags $(LIBS))
+    LDFLAGS += $(shell $(PKG_CONFIG) --libs $(LIBS))
 else ifneq ($(MAKECMDGOALS), clean)
-    MISSING_LIBS = $(shell for lib in $(LIBS) ; do if ! pkg-config --exists $$lib ; then echo $$lib ; fi ; done)
+    MISSING_LIBS = $(shell for lib in $(LIBS) ; do if ! $(PKG_CONFIG) --exists $$lib ; then echo $$lib ; fi ; done)
     $(warning ERROR -- Cannot compile Toxic)
     $(warning ERROR -- You need these libraries)
     $(warning ERROR -- $(MISSING_LIBS))

--- a/cfg/checks/desktop_notifications.mk
+++ b/cfg/checks/desktop_notifications.mk
@@ -3,12 +3,12 @@ DESK_NOTIFY_LIBS = libnotify
 DESK_NOTIFY_CFLAGS = -DBOX_NOTIFY
 
 # Check if we can build desktop notifications support
-CHECK_DESK_NOTIFY_LIBS = $(shell pkg-config --exists $(DESK_NOTIFY_LIBS) || echo -n "error")
+CHECK_DESK_NOTIFY_LIBS = $(shell $(PKG_CONFIG) --exists $(DESK_NOTIFY_LIBS) || echo -n "error")
 ifneq ($(CHECK_DESK_NOTIFY_LIBS), error)
     LIBS += $(DESK_NOTIFY_LIBS)
     CFLAGS += $(DESK_NOTIFY_CFLAGS)
 else ifneq ($(MAKECMDGOALS), clean)
-    MISSING_DESK_NOTIFY_LIBS = $(shell for lib in $(DESK_NOTIFY_LIBS) ; do if ! pkg-config --exists $$lib ; then echo $$lib ; fi ; done)
+    MISSING_DESK_NOTIFY_LIBS = $(shell for lib in $(DESK_NOTIFY_LIBS) ; do if ! $(PKG_CONFIG) --exists $$lib ; then echo $$lib ; fi ; done)
     $(warning WARNING -- Toxic will be compiled without desktop notifications support)
     $(warning WARNING -- You need these libraries for desktop notifications support)
     $(warning WARNING -- $(MISSING_DESK_NOTIFY_LIBS))

--- a/cfg/checks/sound_notifications.mk
+++ b/cfg/checks/sound_notifications.mk
@@ -8,13 +8,13 @@ else
 endif
 
 # Check if we can build sound notifications support
-CHECK_SND_NOTIFY_LIBS = $(shell pkg-config --exists $(SND_NOTIFY_LIBS) || echo -n "error")
+CHECK_SND_NOTIFY_LIBS = $(shell $(PKG_CONFIG) --exists $(SND_NOTIFY_LIBS) || echo -n "error")
 ifneq ($(CHECK_SND_NOTIFY_LIBS), error)
     LIBS += $(SND_NOTIFY_LIBS)
     CFLAGS += $(SND_NOTIFY_CFLAGS)
     OBJ += $(SND_NOTIFY_OBJ)
 else ifneq ($(MAKECMDGOALS), clean)
-    MISSING_SND_NOTIFY_LIBS = $(shell for lib in $(SND_NOTIFY_LIBS) ; do if ! pkg-config --exists $$lib ; then echo $$lib ; fi ; done)
+    MISSING_SND_NOTIFY_LIBS = $(shell for lib in $(SND_NOTIFY_LIBS) ; do if ! $(PKG_CONFIG) --exists $$lib ; then echo $$lib ; fi ; done)
     $(warning WARNING -- Toxic will be compiled without sound notifications support)
     $(warning WARNING -- You need these libraries for sound notifications support)
     $(warning WARNING -- $(MISSING_SND_NOTIFY_LIBS))

--- a/cfg/checks/x11.mk
+++ b/cfg/checks/x11.mk
@@ -4,13 +4,13 @@ X11_CFLAGS = -DX11
 X11_OBJ = xtra.o
 
 # Check if we can build X11 support
-CHECK_X11_LIBS = $(shell pkg-config --exists $(X11_LIBS) || echo -n "error")
+CHECK_X11_LIBS = $(shell $(PKG_CONFIG) --exists $(X11_LIBS) || echo -n "error")
 ifneq ($(CHECK_X11_LIBS), error)
     LIBS += $(X11_LIBS)
     CFLAGS += $(X11_CFLAGS)
     OBJ += $(X11_OBJ)
 else ifneq ($(MAKECMDGOALS), clean)
-    MISSING_X11_LIBS = $(shell for lib in $(X11_LIBS) ; do if ! pkg-config --exists $$lib ; then echo $$lib ; fi ; done)
+    MISSING_X11_LIBS = $(shell for lib in $(X11_LIBS) ; do if ! $(PKG_CONFIG) --exists $$lib ; then echo $$lib ; fi ; done)
     $(warning WARNING -- Toxic will be compiled without x11 support (needed for focus tracking and drag&drop support))
     $(warning WARNING -- You need these libraries for x11 support)
     $(warning WARNING -- $(MISSING_X11_LIBS))

--- a/cfg/global_vars.mk
+++ b/cfg/global_vars.mk
@@ -28,3 +28,6 @@ BINDIR = $(PREFIX)/bin
 DATADIR = $(PREFIX)/share/toxic
 MANDIR = $(PREFIX)/share/man
 APPDIR = $(PREFIX)/share/applications
+
+# Platform tools
+PKG_CONFIG = pkg-config


### PR DESCRIPTION
Some linux distros like Exherbo have target-prefixed tools. `pkg-config` is one of those tools which looks like `x86_64-pc-linux-gnu-pkg-config` on this system. Overriding name of that tool needed for writing proper package in such distros.